### PR TITLE
Add icons to reference and toc callouts

### DIFF
--- a/src/fragments/08-blockquote-callouts.scss
+++ b/src/fragments/08-blockquote-callouts.scss
@@ -103,9 +103,11 @@ body {
   --callout-color: var(--ebw-callout-quote);
 }
 .callout[data-callout="reference"] {
+  --callout-icon: library;
   --callout-color: var(--ebw-callout-reference);
 }
 .callout[data-callout="toc"] {
+  --callout-icon: layout-list;
   --callout-color: var(--ebw-callout-toc);
 }
 .theme-light {


### PR DESCRIPTION
Adds the following Lucide icons:
- Library to Reference
- Layout-List to TOC

Please let me know if I put them in the wrong spot; my first time messing directly with scss files. :)