### PR TITLE
:adhesive_bandage: fix(SCSS): update heading and link styles

### DIFF
--- a/src/fragments/_04-headings-hr-tags.scss
+++ b/src/fragments/_04-headings-hr-tags.scss
@@ -73,7 +73,7 @@ h1,
 .markdown-rendered,
 .workspace,
 .print {
-  .is-live-prevew .HyperMD-header .cm-header::before,
+  .is-live-preview .HyperMD-header .cm-header::before,
   h1::before,
   h2::before,
   h3::before,

--- a/src/fragments/_05-text-links.scss
+++ b/src/fragments/_05-text-links.scss
@@ -24,7 +24,7 @@
 }
 body {
   --link-decoration: underline;
-  --link-decoration-hover: underline
+  --link-decoration-hover: underline;
   --link-external-decoration: underline;
   --link-external-decoration-hover: underline;
 


### PR DESCRIPTION
_04-headings-hr-tags.scss and _05-text-links.scss

Updates these two **only** to address regression in live decoration hover and heading typo.