### PR TITLE
Fix issue with checkbox styles when using tasks-snippet.css with some themes

### DIFF
--- a/src/fragments/_06a-checkbox-mixin.scss
+++ b/src/fragments/_06a-checkbox-mixin.scss
@@ -95,7 +95,7 @@
     background-color: unset;
     background: unset;
 
-    &:after {
+    &::after {
       transform: none;
       -webkit-mask-image: none;
       background: unset;
@@ -109,6 +109,7 @@
       margin-left: calc(-1 * (var(--checkbox-size) / 2));
       color: var(--checkbox-color);
       content: '#{$emoji}';
+      display: block;
     }
   }
 }


### PR DESCRIPTION
With the tasks-snippet.css, the checkboxes aren't rendered properly when used together with certain themes, for example Obsidian Nord.

This change seems to fix the issue. It's possible that some themes change the `::after` element's `display` value to `none` - the `::after` element doesn't appear even in DevTools when inspecting the input elements.

Btw, this snippet is pure gold! Thanks for making it!