### PR TITLE
:sparkles: Add Sync Icon visibility on mobile and tablet

### DIFF
--- a/src/fragments/_03a-workspace-layout.scss
+++ b/src/fragments/_03a-workspace-layout.scss
@@ -244,3 +244,43 @@ body.is-tablet .view-header .view-action,
     }
   }
 }
+
+
+// Sync status icon
+
+:is(.is-mobile, .is-phone) {
+  .workspace:not(:has(.workspace-drawer-backdrop)) {
+    .workspace-drawer.mod-right {
+      display: flex !important;
+      overflow: visible;
+      left: 100%;
+
+      .workspace-drawer-inner {
+        overflow: visible;
+      }
+    }
+    .view-actions {
+      padding-right: 32px;
+
+      &:is(.is-phone) {
+        padding-right: 23px;
+      }
+    }
+  }
+}
+
+.is-phone {
+  .sync-status-icon {
+    position: absolute;
+    top: 0.5rem;
+    left: calc(-1 * 3.25rem);
+  }
+}
+
+.is-tablet {
+  .sync-status-icon {
+    position: absolute;
+    top: 2.3rem;
+    left: calc(-1 * 3.25rem);
+  }
+}


### PR DESCRIPTION
This will close #87

A quickie so we can approve and I can fix the header view actions after. Here are some screenshots. 

Note: I am NOT thrilled by the sync icon sitting on top of the three dots, but its basically invisible on the phone, and is only present when .ebullientworks-reverse-view-header-actions is active and the phone is in vertical. I also could not get the dratted thing to move further up without it breaking the 8th dimension. 

![IMG_0015](https://github.com/ebullient/obsidian-theme-ebullientworks/assets/68425372/10e4fbfc-f5c0-44f4-9669-d2e6fa135baa)

![IMG_3102](https://github.com/ebullient/obsidian-theme-ebullientworks/assets/68425372/efc4e9ff-7758-4cc8-b819-39521e5fb67d)
